### PR TITLE
Fix doc repo link, terminology consistency, and minor grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ This is the repository for RsyncUI, a SwiftUI based macOS application. RsyncUI i
 RsyncUI is a GUI on the Apple macOS platform for the command line tool [rsync](https://github.com/WayneD/rsync). It is `rsync` which executes
 the synchronize data tasks. The GUI is *only* for organizing tasks, setting parameters to `rsync` and make it easier to use `rsync`.
 
-The [user documentation](https://github.com/rsyncOSX/rysyncuidocs) is based upon a fork of the excellent Hugo based theme Docsy.
+The [user documentation](https://rsyncui.netlify.app/docs/)([repo](https://github.com/rsyncOSX/rsyncuidocs)) is based upon a fork of the excellent Hugo based theme [Docsy](https://github.com/google/docsy).
 
 ![](images/rsyncui.png)
 
 | App     | UI                  | Latest version                                                                                      |
 |---------|---------------------|-----------------------------------------------------------------------------------------------------|
 | RsyncUI | SwiftUI, declarativ | v2.6.1 - [July 10, 2025](https://github.com/rsyncOSX/RsyncUI/releases) - in *active development* |
-|  |  | [user guide](https://rsyncui.netlify.app/docs/) and [changelog](https://rsyncui.netlify.app/blog/) |
+|  |  | [documentation](https://rsyncui.netlify.app/docs/) and [changelog](https://rsyncui.netlify.app/blog/) |
 
 ### Install by Homebrew
 
-RsyncUI might be installed by Homebrew or by direct Download. It is signed and notarized by Apple.
+RsyncUI might be installed by Homebrew or by direct download. It is signed and notarized by Apple.
 
 | App      | Homebrew | macOS |
 | ----------- | ----------- |   ----------- |


### PR DESCRIPTION
I know docs site is linked in the side bar but the link is prominent in the readme I ended up clicking that first and getting taken to the repo. Spotted some other issues too

- link to docs site url
- https://github.com/rsyncOSX/rysyncuidocs -> https://github.com/rsyncOSX/rsyncuidocs
- user guide -> documentation
- direct Download -> download